### PR TITLE
updates to allow sims with no lattice file

### DIFF
--- a/genesis/genesis.py
+++ b/genesis/genesis.py
@@ -122,7 +122,11 @@ class Genesis:
         return self.input['beam']    
     @property
     def lattice(self):
-        return self.input['lattice']
+        try: 
+            return self.input['lattice']
+        except:
+            print('No lattice found, assuming lattice is defined in input file.')
+            return None
     @property
     def param(self):
         return self.input['param']    
@@ -259,8 +263,7 @@ class Genesis:
     def write_lattice(self):
     
         if not self.lattice:
-            print('Error, no lattice to write')
-            return
+            self.input['lattice'] = None
     
         else:
             filePath = os.path.join(self.path, self.param['maginfile'])


### PR DESCRIPTION
A small update for the uspas FEL class. If there is no lattice file, it is assumed that a lattice is defined in the input file. A message is printed to let the user know this assumption is being made. 