### PR TITLE
ENH: an example of load_profile_multi

### DIFF
--- a/docs/examples/genesis4/data/basic4/cu_hxr_multi.in
+++ b/docs/examples/genesis4/data/basic4/cu_hxr_multi.in
@@ -1,0 +1,56 @@
+# Comment 1
+&setup
+  rootname=LCLS2_HXR_9keV # Comment 2
+  lattice=hxr.lat
+  # Comment 3
+  beamline=HXR
+  lambda0 = 1.3789244869952112e-10
+  gamma0 = 19174.0776
+  delz=0.026
+  seed=84672
+  npart=1024
+  
+&end
+
+&time
+  slen=15.0e-6
+  sample = 200
+&end
+
+&field
+  dgrid=0.1e-3
+  ngrid=101
+  accumulate = true
+&end
+
+&profile_file_multi
+label_prefix=beam
+file=beam_current.h5
+xdata=s
+ydata=current
+&end
+
+&profile_file_multi
+label_prefix=beam
+file=beam_gamma.h5
+xdata=s
+ydata=gamma
+&end
+
+
+&beam
+current = @beam.current
+gamma = @beam.gamma
+delgam = 3.97848
+ex = 4.000000e-07
+ey = 4.000000e-07
+alphax = -0.7393217413918415 
+betax = 7.910909406464387
+alphay = 1.3870723536888105 
+betay = 16.8811786213468987
+&end
+
+&track
+field_dump_at_undexit = false
+zstop = 10
+&end


### PR DESCRIPTION
* Add example of `load_profile_multi` which was previously undocumented
   * Now it's documented, but slightly incorrectly (see [here](https://svenreiche.github.io/Genesis-1.3-Version4/#profile_file_multi))
* I think this avoids the `file.h5/group` syntax of `profile_file` rather well

What do you think, @ChristopherMayes ?

The output is as follows:

<details>

```
$ genesis4 cu_hxr_multi.in
---------------------------------------------
GENESIS - Version 4.6.4 has started...
Compile info: Compiled by runner at 2023-12-16 00:59:36 [UTC] from Git Commit ID:
Starting Time: Wed Jan 17 11:58:53 2024

MPI-Comm Size: 1 node

Parsing lattice file...
Setting up time window of 15.0027 microns with 544 sample points...
Generating input radiation field for HARM = 1 ...
Adding profile with label: beam.current
Adding profile with label: beam.gamma
Generating input particle distribution...

Running Core Simulation...
Time-dependent run with 544 slices for a time window of 15.0027 microns
Initial analysis of electron beam and radiation field...
  Calculation: 0% done
  Calculation: 10% done
  Calculation: 20% done
  Calculation: 30% done
  Calculation: 40% done
  Calculation: 50% done
  Calculation: 60% done
  Calculation: 70% done
  Calculation: 80% done
  Calculation: 90% done
  Calculation: 100% done
Calculation terminated due to requested stop.
Writing output file...

Core Simulation done.
Diagnostic::~Diagnostic()
End of Track

Program is terminating...
Ending Time: Wed Jan 17 12:01:00 2024
Total Wall Clock Time: 125.721 seconds
-------------------------------------
```
</details>