### PR TITLE
REF: insert particles after Time (and Setup as a fallback); remove others always

### DIFF
--- a/genesis/version4/input/core.py
+++ b/genesis/version4/input/core.py
@@ -507,15 +507,17 @@ class MainInput(BaseModel):
             previous = self.import_field
         except NamelistAccessError:
             if self.fields:
+                # Before Field, if it exists
                 insert_pos = self.namelists.index(self.fields[0])
             elif self.times:
+                # Otherwise, it needs to come after Time
                 insert_pos = self.namelists.index(self.times[-1]) + 1
             else:
                 logger.warning(
                     "Unable to determine where to insert the importfield; "
                     "placing it after 'setup'"
                 )
-                insert_pos = self.namelists.index(self.setup)
+                insert_pos = self.namelists.index(self.setup) + 1
         else:
             insert_pos = self.namelists.index(previous)
             self.remove(previous)


### PR DESCRIPTION
## Changes

This PR adjusts `initial_particles` and `initial_field` handling:

* Remove other unused `Beam` instances when inserting particles
* Remove `ImportDistribution` instances when inserting an `ImportBeam` instance
* Remove `ImportBeam` instances when inserting an `ImportDistribution` instance
* Fix `initial_field` fallback to insert _after_ `setup` (off-by-one error)
