### PR TITLE
DOC/BLD: remove polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,6 @@ markdown_extensions:
 extra_javascript:
   # The following are for mathjax rendering of LaTeX formulas:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra:


### PR DESCRIPTION
It seems `polyfill` isno longer required per the docs: https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-mkdocsyml And perhaps that site is also a security concern.