### PR TITLE
ENH: add G.input setter check

### DIFF
--- a/genesis/tests/genesis4/test_run.py
+++ b/genesis/tests/genesis4/test_run.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 import pytest
 
+from ... import version4 as g4
 from ...version4 import Genesis4
 from ...version4.input import Beam, Lattice, MainInput
-from ..conftest import test_root
+from ..conftest import genesis4_example1_path, test_root
 from .conftest import run_basic
 from .util import run_with_instances, run_with_source
 
@@ -101,8 +102,6 @@ def test_get_run_prefix_smoke(genesis4: Genesis4, nproc: int, mpi: bool) -> None
 
 
 def test_run_3rd_harmonic():
-    from ... import version4 as g4
-
     main = g4.MainInput(
         [
             g4.Setup(
@@ -145,3 +144,14 @@ def test_run_3rd_harmonic():
     field_data = output.load_field_by_key("h3")
     assert field_data.label == "h3"
     assert field_data.param.gridpoints == 255
+
+
+def test_input_setter():
+    G = g4.Genesis4(genesis4_example1_path / "Example1.in")
+
+    with pytest.raises(ValueError):
+        G.input = None
+
+    new = g4.Genesis4Input(main=g4.MainInput(), lattice=g4.Lattice())
+    G.input = new
+    assert G.input is new

--- a/genesis/version4/run.py
+++ b/genesis/version4/run.py
@@ -184,7 +184,7 @@ class Genesis4(CommandWrapper):
     command_mpi_env: str = "GENESIS4_BIN"
     original_path: AnyPath
 
-    input: Genesis4Input
+    _input: Genesis4Input
     output: Optional[Genesis4Output]
 
     def __init__(
@@ -249,7 +249,7 @@ class Genesis4(CommandWrapper):
             workdir = pathlib.Path(".")
 
         self.original_path = workdir
-        self.input = input
+        self._input = input
         self.output = output
 
         # Internal
@@ -259,6 +259,21 @@ class Genesis4(CommandWrapper):
         # MPI
         self.nproc = 1
         self.nnode = 1
+
+    @property
+    def input(self) -> Genesis4Input:
+        """The Genesis 4 input, including namelists and lattice information."""
+        return self._input
+
+    @input.setter
+    def input(self, inp: Any) -> None:
+        if not isinstance(inp, Genesis4Input):
+            raise ValueError(
+                f"The provided input is of type {type(inp).__name__} and not `Genesis4Input`. "
+                f"Please consider creating a new Genesis4 object instead with the "
+                f"new parameters!"
+            )
+        self._input = inp
 
     @property
     def nproc(self):


### PR DESCRIPTION
## Background

A user ran into a scenario where they were confused as to why the following did not run:
```python
G = g4.Genesis4()
G.input = [{"type": "setup"}, ...]
G.run()
```

Working with dictionaries directly on the `Genesis4` object is unsupported. As noted in the [migration example](https://slaclab.github.io/lume-genesis/examples/genesis4/intro-5-Migrating/), the following is possible:

```python
main = g4.MainInput.from_dicts([{"type": "setup"}])
G = g4.Genesis4(main)
```

## Changes

* This PR adds validation for the `G.input` setter (stashing the actual input in `_input`)
* It suggests to the user to make a new Genesis object instead as it's much more flexible and with less typing