### PR TITLE
FIX/TST: field harmonic access

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -20,10 +20,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Mambaforge
+    - name: Setup miniforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         activate-environment: ${{ inputs.env_name }}
         use-mamba: true
         channels: conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - lume-base
   - genesis2=*=mpi_openmpi*
   - genesis4 >=4.6.6=mpi_openmpi*
+  - h5py=*=mpi_openmpi*
   - jinja2
   - lark
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -34,5 +34,6 @@ dependencies:
   - mkdocstrings-python
   - ruff
   - typing-extensions
+  - pip
   - pip:
       - mkdocs-jupyter>=0.24.7

--- a/genesis/tests/genesis4/test_notebooks.py
+++ b/genesis/tests/genesis4/test_notebooks.py
@@ -595,6 +595,8 @@ def test_fodo_scan_model(_shorten_zstop, tmp_path: pathlib.Path) -> None:
     plt.legend(title=r"$\lambda_u$ (mm)")
 
 
+@pytest.mark.filterwarnings("ignore:Attempt to set non-positive")
+@pytest.mark.filterwarnings("ignore:More than 20")
 def test_genesis4_example(_shorten_zstop, tmp_path: pathlib.Path) -> None:
     G = Genesis4(
         genesis4_examples / "data/basic4/cu_hxr.in",

--- a/genesis/tests/genesis4/test_output.py
+++ b/genesis/tests/genesis4/test_output.py
@@ -289,3 +289,18 @@ def test_field_harmonic_alias_access():
     output = G.run()
 
     assert output.field_harmonics[3].energy is output["field3_energy"]
+    assert output.field_harmonics[1].energy is output["field_energy"]
+
+    # Ensure that the base genesis object is able to access it, as well.
+    # It checks the
+    G.plot(
+        "field_energy",
+        yscale="linear",
+        y2=["beam_xsize", "beam_ysize"],
+    )
+    G.plot(
+        "field3_energy",
+        yscale="linear",
+        y2=["beam_xsize", "beam_ysize"],
+    )
+    output.info()


### PR DESCRIPTION
## Background

A user reported that `G.plot("field3_energy")` was not working correctly.

These aliases, introduced in #41, lacked full test coverage - merely ensuring that `output["field3_energy"]` would return the correct value. The plot functions require more information about the array - units and such. This was broken in the latest release, resulting in this error message:

```
AttributeError: 'Genesis4Output' object has no attribute 'field_harmonics[3]'
```

## Changes

* Fixed `plot("fieldN_...")` by consolidating alias handling into a single method, such that array information and value are retrieved from similar code paths
* Added a test that generates 3rd harmonic output that can be investigated and plotted
* Fixed up some continuous integration issues (deprecation of mambaforge, h5py addition)
* Silenced some warnings from the test suite