### PR TITLE
REF: include particles in archive

### DIFF
--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -1383,7 +1383,6 @@ class Genesis4Output(Mapping, BaseModel, arbitrary_types_allowed=True):
     )
     particles: Dict[FileKey, ParticleGroup] = pydantic.Field(
         default_factory=dict,
-        exclude=True,
         description="Loaded particle data, keyed by integration step number or filename base.",
     )
     alias: Dict[str, str] = pydantic.Field(


### PR DESCRIPTION
Closes #57 

It was previously stated that particles were too large to be included in the archive, hence [the exclusion](https://github.com/slaclab/lume-genesis/blob/b46b087c6064ac2ccf950e61ea22049ab9de9439/genesis/version4/output.py#L1386).

With this PR, any _**loaded**_ particles should now be included in the archive.