### PR TITLE
MAINT/FIX: harden archive functions to use fixed-width byte strings

### DIFF
--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -43,6 +43,7 @@ from ...version4 import (
     Wake,
     Write,
 )
+from ...version4.archive import store_in_hdf5_file, restore_from_hdf5_file
 from ...version4.types import BeamlineElement, NameList
 from ..conftest import test_artifacts
 from . import util
@@ -241,3 +242,21 @@ def test_hdf_archive_using_group(
     orig_output_repr = repr(orig_output)
     restored_output_repr = repr(genesis4.output)
     assert orig_output_repr == restored_output_repr
+
+
+class StringModel(BaseModel):
+    str_value: str
+    bytes_value: bytes
+
+
+def test_null_bytes_storage(hdf5_filename: pathlib.Path):
+    orig = StringModel(str_value="one\0two\0three", bytes_value=b"one\0two\0three")
+    with h5py.File(hdf5_filename, "w") as h5:
+        store_in_hdf5_file(h5, orig)
+
+    with h5py.File(hdf5_filename, "r") as h5:
+        output = restore_from_hdf5_file(h5)
+
+    print(orig)
+    print(output)
+    assert orig == output

--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -5,6 +5,7 @@ from typing import Union
 
 import h5py
 import pytest
+from pmd_beamphysics import ParticleGroup
 from pydantic import BaseModel
 
 from ...version4 import (
@@ -43,7 +44,11 @@ from ...version4 import (
     Wake,
     Write,
 )
-from ...version4.archive import store_in_hdf5_file, restore_from_hdf5_file
+from ...version4.archive import (
+    store_in_hdf5_file,
+    restore_from_hdf5_file,
+    pick_from_archive,
+)
 from ...version4.types import BeamlineElement, NameList
 from ..conftest import test_artifacts
 from . import util
@@ -193,6 +198,32 @@ def test_hdf_archive_particles(
         particles = orig_particles[key]
         print("Checking particles", particles)
         assert particles == new_output.particles[key]
+
+
+def test_pick_from_archive(
+    genesis4: Genesis4,
+    hdf5_filename: pathlib.Path,
+) -> None:
+    genesis4.input.main.namelists.append(Write(beam="end"))
+    orig_output = genesis4.run(raise_on_error=True)
+    assert orig_output.run.success
+
+    orig_output.load_particles()
+
+    orig_particles = orig_output.particles
+    assert len(orig_output.particles)
+
+    genesis4.archive(hdf5_filename)
+
+    with h5py.File(hdf5_filename) as h5:
+        for key in orig_output.particles:
+            particles = orig_particles[key]
+            print("Checking particles", particles)
+
+            loaded = pick_from_archive(h5[f"output/particles/{key}"])
+            assert isinstance(loaded, ParticleGroup)
+            assert loaded == particles
+            assert loaded.species == "electron"
 
 
 def json_for_comparison(model: BaseModel) -> str:

--- a/genesis/tools.py
+++ b/genesis/tools.py
@@ -113,7 +113,7 @@ def execute(cmd, cwd=None):
 
 
 # Alternative execute
-def execute2(cmd, timeout=None, cwd=None):
+def execute2(cmd, timeout=None, cwd=None, encoding="utf-8"):
     """
     Execute with time limit (timeout) in seconds, catching run errors.
     """
@@ -132,11 +132,21 @@ def execute2(cmd, timeout=None, cwd=None):
         output["why_error"] = ""
     except subprocess.TimeoutExpired as ex:
         stdout = ex.stdout or b""
-        output["log"] = "\n".join((stdout.decode(), f"{ex.__class__.__name__}: {ex}"))
+        output["log"] = "\n".join(
+            (
+                stdout.decode(encoding, errors="ignore"),
+                f"{ex.__class__.__name__}: {ex}",
+            )
+        )
         output["why_error"] = "timeout"
     except subprocess.CalledProcessError as ex:
         stdout = ex.stdout or b""
-        output["log"] = "\n".join((stdout.decode(), f"{ex.__class__.__name__}: {ex}"))
+        output["log"] = "\n".join(
+            (
+                stdout.decode(encoding, errors="ignore"),
+                f"{ex.__class__.__name__}: {ex}",
+            )
+        )
         output["why_error"] = "error"
     except Exception as ex:
         stack = traceback.print_exc()

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -335,3 +335,15 @@ def restore_from_hdf5_file(
     for key in _reserved_h5_attrs:
         data.pop(key, None)
     return cls.model_validate(data)
+
+
+def pick_from_archive(h5: h5py.Group, encoding: str = "utf-8"):
+    """
+    Restore a single instance from an HDF5 file archive.
+
+    Parameters
+    ----------
+    h5 : h5py.Group
+        The file or group to restore from.
+    """
+    return _hdf5_restore_dict(h5, encoding=encoding)

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -42,7 +42,7 @@ def _hdf5_dictify(data, encoding: str):
             "value": str(data),
         }
     if isinstance(data, str):
-        return data.encode(encoding)
+        return np.bytes_(data.encode(encoding))
     if isinstance(data, (int, float, bool)):
         return data
     if isinstance(data, bytes):
@@ -50,7 +50,7 @@ def _hdf5_dictify(data, encoding: str):
         # byte datasets are encoded strings unless marked like so:
         return {
             "__python_class_name__": "bytes",
-            "value": data,
+            "value": np.bytes_(data),
         }
     if isinstance(data, np.ndarray):
         return data
@@ -159,7 +159,9 @@ def _hdf5_store_dict(group: h5py.Group, data, encoding: str, depth=0) -> None:
                 depth=depth + 1,
                 encoding=encoding,
             )
-        elif isinstance(value, (str, bytes, int, float, bool)):
+        elif isinstance(value, bytes):
+            group.attrs[h5_key] = np.bytes_(value)
+        elif isinstance(value, (str, int, float, bool)):
             group.attrs[h5_key] = value
         elif isinstance(value, (np.ndarray,)):
             group.create_dataset(h5_key, data=value)
@@ -279,6 +281,10 @@ def _hdf5_restore_dict(
         if hasattr(value, "tolist"):
             # Get the native type from a numpy scalar
             value = value.tolist()
+
+        if isinstance(value, bytes):
+            value = value.decode(encoding)
+
         res_by_hdf5_key[key] = value
 
     key_map_json = item.attrs.get("__python_key_map__", None)

--- a/genesis/version4/run.py
+++ b/genesis/version4/run.py
@@ -395,7 +395,7 @@ class Genesis4(CommandWrapper):
             start_time=start_time,
             end_time=end_time,
             run_time=end_time - start_time,
-            output_log=execute_result["log"],
+            output_log=execute_result["log"].replace("\x00", ""),
         )
 
         success_or_failure = "Success" if not execute_result["error"] else "Failure"


### PR DESCRIPTION
## Changes

* Ensure we're using `np.bytes_()` to make variable length byte strings fixed length ([per the docs](https://docs.h5py.org/en/latest/strings.html) and [numpy](https://numpy.org/doc/stable/user/basics.strings.html#fixed-width-data-types))
* Also pre-emptively remove null characters found in genesis4 command output.

Fixes scenario where Genesis4 output erroneously has null characters at the start of its output:
```python
{"output_log": array(b'\x00---------------------------------------------\nGENESIS - Version 4.6.7 has started...\
...}
```

## TODO

- [x] Ensure this update still loads archives from previous versions of lume-genesis