### PR TITLE
BLD: remove options section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=60",
-  "setuptools_scm[toml]>=8.0"
-]
+requires = ["setuptools>=60", "setuptools_scm[toml]>=8.0"]
 
 [project]
-authors = [
-  {name="Christopher Mayes"},
-]
+authors = [{ name = "Christopher Mayes" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
@@ -20,17 +15,14 @@ dependencies = [
   # See ``environment.yml`` for further information.
 ]
 description = "LUME tools for using Genesis 1.3 version 2 and version 4"
-dynamic = [ "version" ]
+dynamic = ["version"]
 keywords = []
 name = "lume-genesis"
-readme = {file = "README.md", content-type = "text/markdown"}
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-dev = [
-  "pytest",
-  "pytest-cov",
-]
+dev = ["pytest", "pytest-cov"]
 doc = [
   "mkdocs",
   "mkdocs-jupyter",
@@ -43,13 +35,9 @@ doc = [
 [project.urls]
 Homepage = "https://github.com/slaclab/lume-genesis"
 
-[options]
-zip_safe = false
-include_package_data = true
-
 [tool.setuptools.packages.find]
 where = ["."]
-include = [ "genesis*", ]
+include = ["genesis*"]
 namespaces = false
 
 [project.license]


### PR DESCRIPTION
Closes #60 

* Removes `options.zip_safe` (wrong section deprecated) and `options.include_package_data` (wrong section and now the default anyway)
* Reformats the pyproject.toml file as well for good measure