### PR TITLE
FIX: __get_pydantic_core_schema__ classes shouldn't inherit from BaseModel

### DIFF
--- a/genesis/version4/types.py
+++ b/genesis/version4/types.py
@@ -151,7 +151,7 @@ class BaseModel(pydantic.BaseModel, extra="forbid", validate_assignment=True):
         ]
 
 
-class _PydanticParticleGroup(pydantic.BaseModel):
+class _PydanticParticleGroup:
     data: ParticleData
 
     @staticmethod
@@ -185,7 +185,7 @@ class _PydanticParticleGroup(pydantic.BaseModel):
         raise ValueError(f"No conversion from {value!r} to ParticleGroup")  # type: ignore[unreachable]
 
 
-class _PydanticPmdUnit(BaseModel):
+class _PydanticPmdUnit:
     unitSI: float
     unitSymbol: str
     unitDimension: Tuple[int, ...]
@@ -229,7 +229,7 @@ class _PydanticPmdUnit(BaseModel):
         raise ValueError(f"No conversion from {value!r} to pmd_unit")
 
 
-class _PydanticNDArray(BaseModel):
+class _PydanticNDArray:
     @classmethod
     def __get_pydantic_core_schema__(
         cls,


### PR DESCRIPTION
Closes #62 (see details in the issue, helpfully provided by a pydantic contributor)

As the pydantic validation and archive round-tripping will verify this works as intended in the test suite, if CI passes this should be good-to-go.