### PR TITLE
Only modify slen when time_.slen <  particles_slen

### DIFF
--- a/docs/examples/genesis4/genesis4_particles.ipynb
+++ b/docs/examples/genesis4/genesis4_particles.ipynb
@@ -445,7 +445,7 @@
     "            seed=123456,\n",
     "            npart=512,\n",
     "        ),\n",
-    "        g4.Time(),\n",
+    "        g4.Time(slen=0),  # This will change slen to span all particles\n",
     "        g4.Track(zstop=1),\n",
     "        g4.Write(beam=\"end\"),\n",
     "    ],\n",
@@ -570,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/genesis/version4/input/core.py
+++ b/genesis/version4/input/core.py
@@ -636,12 +636,13 @@ class MainInput(BaseModel):
             self.remove(previous)
 
         if update_slen and isinstance(particles, ParticleGroup):
+            particles_slen = get_particles_slen(particles)
             for time_ in self.times:
                 was = time_.slen
-                time_.slen = get_particles_slen(particles)
-                if time_.slen != was:
+                if was < particles_slen:
+                    time_.slen = particles_slen
                     logger.warning(
-                        "Updating time namelist slen: %f (was %f)",
+                        "Updating time namelist slen: %f (was %f) to span all particles",
                         time_.slen,
                         was,
                     )
@@ -1227,12 +1228,14 @@ class Genesis4Input(BaseModel):
                     f"now={self.initial_particles.charge}"
                 )
                 dist.charge = self.initial_particles.charge
+
+            particles_slen = get_particles_slen(self.initial_particles)
             for time_ in self.main.times:
                 was = time_.slen
-                time_.slen = get_particles_slen(self.initial_particles)
-                if time_.slen != was:
+                if was < particles_slen:
+                    time_.slen = particles_slen
                     logger.warning(
-                        f"Updating time namelist slen: was={was} now {time_.slen}",
+                        f"Updating time namelist slen: was={was} now {time_.slen} to span all particles",
                     )
         else:
             raise ValueError(


### PR DESCRIPTION
Previously `slen` was modified when `initial_particles` were present. This was a mistake, because the user may be interested cases where the bunch is short.

This PR modifies the logic so that `slen` is only modified when the original `slen` was less than the particles' width.
