### PR TITLE
CI: Minor tweak to PyPI deployment

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -56,6 +56,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     environment:
       name: testpypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,5 @@ testpaths = ["genesis/tests"]
 
 [tool.setuptools_scm]
 version_file = "genesis/_version.py"
+# For publishing to testpypi (no local dev+hash suffix)
+local_scheme = "no-local-version"


### PR DESCRIPTION
* Don't use `dev+hash` suffix, otherwise the testpypi deployment will fail
* The `testpypi` job can fail without interrupting any workflow