### PR TITLE
ENH: add msgpack as an alternative (and faster) archive format

### DIFF
--- a/docs/examples/genesis4/bmad_genesis4.ipynb
+++ b/docs/examples/genesis4/bmad_genesis4.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "import numpy as np"
    ]
   },

--- a/docs/examples/genesis4/intro-1-Quickstart.ipynb
+++ b/docs/examples/genesis4/intro-1-Quickstart.ipynb
@@ -280,11 +280,64 @@
    "source": [
     "G == restored"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab2d8687",
+   "metadata": {},
+   "source": [
+    "## Archive the results to a MessagePack file\n",
+    "\n",
+    "Saving and loading from MessagePack can be much faster, however it is less introspectable than HDF5.\n",
+    "The choice is yours as to which to use.\n",
+    "\n",
+    "Simply use the `.msgpack` file extension (or set `format=\"msgpack\"`) when archiving."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "897e2e32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.archive(\"quickstart-results.msgpack\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "887b46e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "restored = Genesis4.from_archive(\"quickstart-results.msgpack\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a23ad305",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "restored.output.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "816e6efc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G == restored"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "kyber",
    "language": "python",
    "name": "python3"
   },
@@ -298,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/examples/genesis4/intro-1-Quickstart.ipynb
+++ b/docs/examples/genesis4/intro-1-Quickstart.ipynb
@@ -220,7 +220,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output.info()"
+    "output.info(limit=20)\n",
+    "\n",
+    "# **NOTE**: there is a lot more here! Use `output.info()` with the default `limit=None` to see everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1322d23b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment this to see everything available in the output.\n",
+    "# output.info(limit=None)"
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - matplotlib
   - numpy
   - openpmd-beamphysics >=0.11.0
+  - ormsgpack
   - prettytable
   - psutil
   - pydantic >2

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - ormsgpack
   - prettytable
   - psutil
-  - pydantic >2
+  - pydantic >=2.12.0
   - pydantic-settings
   - typing-extensions
   # Genesis - OpenMPI variants

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - lume-base
   - matplotlib
   - numpy
-  - openpmd-beamphysics >=0.11.0
+  - openpmd-beamphysics >=0.14.1
   - ormsgpack
   - prettytable
   - psutil

--- a/genesis/particles.py
+++ b/genesis/particles.py
@@ -1,5 +1,5 @@
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.interfaces.genesis import genesis2_dpa_to_data
+from beamphysics import ParticleGroup
+from beamphysics.interfaces.genesis import genesis2_dpa_to_data
 
 
 def final_particles(genesis_object):

--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -57,6 +57,14 @@ from . import util
 
 
 @pytest.fixture
+def msgpack_filename(
+    tmp_path: pathlib.Path,
+    request: pytest.FixtureRequest,
+) -> pathlib.Path:
+    return tmp_path / f"{request.node.name}.msgpack"
+
+
+@pytest.fixture
 def hdf5_filename(
     tmp_path: pathlib.Path,
     request: pytest.FixtureRequest,
@@ -295,3 +303,88 @@ def test_null_bytes_storage(hdf5_filename: pathlib.Path):
     print(orig)
     print(output)
     assert orig == output
+
+
+def test_msgpack_archive(
+    genesis4: Genesis4,
+    msgpack_filename: pathlib.Path,
+) -> None:
+    output = genesis4.run(raise_on_error=True)
+    assert output.run.success
+
+    genesis4.load_output()
+    orig_input = genesis4.input
+    orig_output = genesis4.output
+    assert orig_output is not None
+
+    t0 = time.monotonic()
+    genesis4.archive(msgpack_filename, format="msgpack")
+
+    t1 = time.monotonic()
+    genesis4.load_archive(msgpack_filename)
+
+    t2 = time.monotonic()
+    print("Took", t1 - t0, "s to archive")
+    print("Took", t2 - t1, "s to restore")
+    assert genesis4.output is not None
+
+    # assert orig_input.model_dump_json(indent=True) == genesis4.input.model_dump_json(indent=True)
+    # assert orig_output.model_dump_json(indent=True) == genesis4.output.model_dump_json(indent=True)
+    orig_input_repr = repr(orig_input)
+    restored_input_repr = repr(genesis4.input)
+    assert orig_input_repr == restored_input_repr
+
+    orig_output_repr = repr(orig_output)
+    restored_output_repr = repr(genesis4.output)
+    assert orig_output_repr == restored_output_repr
+
+    if orig_input != genesis4.input:
+        util.compare(orig_input, genesis4.input)
+        assert False, "Verbose comparison should have failed?"
+    if orig_output != genesis4.output:
+        util.compare(orig_output, genesis4.output)
+        assert False, "Verbose comparison should have failed?"
+
+    with open(test_artifacts / "orig_input.json", "wt") as fp:
+        print(json_for_comparison(orig_input), file=fp)
+    with open(test_artifacts / "restored_input.json", "wt") as fp:
+        print(json_for_comparison(genesis4.input), file=fp)
+    with open(test_artifacts / "orig_output.json", "wt") as fp:
+        print(json_for_comparison(orig_output), file=fp)
+    with open(test_artifacts / "restored_output.json", "wt") as fp:
+        print(json_for_comparison(genesis4.output), file=fp)
+
+    assert json_for_comparison(orig_input) == json_for_comparison(genesis4.input)
+    assert json_for_comparison(orig_output) == json_for_comparison(genesis4.output)
+
+
+def test_msgpack_archive_particles(
+    genesis4: Genesis4,
+    msgpack_filename: pathlib.Path,
+) -> None:
+    genesis4.input.main.namelists.append(Write(beam="end"))
+    orig_output = genesis4.run(raise_on_error=True)
+    assert orig_output.run.success
+
+    orig_output.load_particles()
+
+    orig_particles = orig_output.particles
+    assert len(orig_output.particles)
+
+    t0 = time.monotonic()
+    genesis4.archive(msgpack_filename, format="msgpack")
+
+    t1 = time.monotonic()
+    genesis4.load_archive(msgpack_filename)
+    new_output = genesis4.output
+
+    t2 = time.monotonic()
+    print("Took", t1 - t0, "s to archive")
+    print("Took", t2 - t1, "s to restore")
+    assert new_output is not None
+    assert list(new_output.particles) == list(orig_particles)
+
+    for key in new_output.particles:
+        particles = orig_particles[key]
+        print("Checking particles", particles)
+        assert particles == new_output.particles[key]

--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -150,6 +150,20 @@ def test_hdf_archive(
     print("Took", t2 - t1, "s to restore")
     assert genesis4.output is not None
 
+    with open(test_artifacts / "hdf_orig_input.json", "wt") as fp:
+        print(json_for_comparison(orig_input), file=fp)
+    with open(test_artifacts / "hdf_restored_input.json", "wt") as fp:
+        print(json_for_comparison(genesis4.input), file=fp)
+    with open(test_artifacts / "hdf_orig_output.json", "wt") as fp:
+        print(json_for_comparison(orig_output), file=fp)
+    with open(test_artifacts / "hdf_restored_output.json", "wt") as fp:
+        print(json_for_comparison(genesis4.output), file=fp)
+
+    with open(test_artifacts / "hdf_orig_output_repr.txt", "wt") as fp:
+        print(repr(orig_output), file=fp)
+    with open(test_artifacts / "hdf_restored_output_repr.txt", "wt") as fp:
+        print(repr(genesis4.output), file=fp)
+
     # assert orig_input.model_dump_json(indent=True) == genesis4.input.model_dump_json(indent=True)
     # assert orig_output.model_dump_json(indent=True) == genesis4.output.model_dump_json(indent=True)
     orig_input_repr = repr(orig_input)
@@ -166,15 +180,6 @@ def test_hdf_archive(
     if orig_output != genesis4.output:
         util.compare(orig_output, genesis4.output)
         assert False, "Verbose comparison should have failed?"
-
-    with open(test_artifacts / "orig_input.json", "wt") as fp:
-        print(json_for_comparison(orig_input), file=fp)
-    with open(test_artifacts / "restored_input.json", "wt") as fp:
-        print(json_for_comparison(genesis4.input), file=fp)
-    with open(test_artifacts / "orig_output.json", "wt") as fp:
-        print(json_for_comparison(orig_output), file=fp)
-    with open(test_artifacts / "restored_output.json", "wt") as fp:
-        print(json_for_comparison(genesis4.output), file=fp)
 
     assert json_for_comparison(orig_input) == json_for_comparison(genesis4.input)
     assert json_for_comparison(orig_output) == json_for_comparison(genesis4.output)
@@ -241,7 +246,8 @@ def test_pick_from_archive(
 def json_for_comparison(model: BaseModel) -> str:
     # Assuming dictionary keys can't be assumed to be sorted
     data = json.loads(model.model_dump_json())
-    return json.dumps(data, sort_keys=True, indent=True)
+    data = json.dumps(data, sort_keys=True, indent=True)
+    return data.replace("array(shape=(0,), dtype=float64)", "array([], dtype=float64)")
 
 
 def test_hdf_archive_using_group(
@@ -278,10 +284,12 @@ def test_hdf_archive_using_group(
     # with open("restored_output.json", "wt") as fp:
     #     print(json_for_comparison(genesis4.output), file=fp)
 
+    assert orig_input == genesis4.input
     orig_input_repr = repr(orig_input)
     restored_input_repr = repr(genesis4.input)
     assert orig_input_repr == restored_input_repr
 
+    assert orig_output == genesis4.output
     orig_output_repr = repr(orig_output)
     restored_output_repr = repr(genesis4.output)
     assert orig_output_repr == restored_output_repr
@@ -328,6 +336,22 @@ def test_msgpack_archive(
     print("Took", t2 - t1, "s to restore")
     assert genesis4.output is not None
 
+    with open(test_artifacts / "msgpack_orig_input.json", "wt") as fp:
+        print(json_for_comparison(orig_input), file=fp)
+    with open(test_artifacts / "msgpack_restored_input.json", "wt") as fp:
+        print(json_for_comparison(genesis4.input), file=fp)
+    with open(test_artifacts / "msgpack_orig_output.json", "wt") as fp:
+        print(json_for_comparison(orig_output), file=fp)
+    with open(test_artifacts / "msgpack_restored_output.json", "wt") as fp:
+        print(json_for_comparison(genesis4.output), file=fp)
+
+    if orig_input != genesis4.input:
+        util.compare(orig_input, genesis4.input)
+        assert False, "Verbose comparison should have failed?"
+    if orig_output != genesis4.output:
+        util.compare(orig_output, genesis4.output)
+        assert False, "Verbose comparison should have failed?"
+
     # assert orig_input.model_dump_json(indent=True) == genesis4.input.model_dump_json(indent=True)
     # assert orig_output.model_dump_json(indent=True) == genesis4.output.model_dump_json(indent=True)
     orig_input_repr = repr(orig_input)
@@ -337,22 +361,6 @@ def test_msgpack_archive(
     orig_output_repr = repr(orig_output)
     restored_output_repr = repr(genesis4.output)
     assert orig_output_repr == restored_output_repr
-
-    if orig_input != genesis4.input:
-        util.compare(orig_input, genesis4.input)
-        assert False, "Verbose comparison should have failed?"
-    if orig_output != genesis4.output:
-        util.compare(orig_output, genesis4.output)
-        assert False, "Verbose comparison should have failed?"
-
-    with open(test_artifacts / "orig_input.json", "wt") as fp:
-        print(json_for_comparison(orig_input), file=fp)
-    with open(test_artifacts / "restored_input.json", "wt") as fp:
-        print(json_for_comparison(genesis4.input), file=fp)
-    with open(test_artifacts / "orig_output.json", "wt") as fp:
-        print(json_for_comparison(orig_output), file=fp)
-    with open(test_artifacts / "restored_output.json", "wt") as fp:
-        print(json_for_comparison(genesis4.output), file=fp)
 
     assert json_for_comparison(orig_input) == json_for_comparison(genesis4.input)
     assert json_for_comparison(orig_output) == json_for_comparison(genesis4.output)

--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import h5py
 import pytest
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 from pydantic import BaseModel
 
 from ...version4 import (

--- a/genesis/tests/genesis4/test_initial_particles.py
+++ b/genesis/tests/genesis4/test_initial_particles.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy as np
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 from ...version4 import (
     Genesis4,

--- a/genesis/tests/genesis4/test_notebooks.py
+++ b/genesis/tests/genesis4/test_notebooks.py
@@ -20,7 +20,7 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 from ... import version4 as g4
 from ...version4 import Genesis4, Lattice, MainInput, Track, Write

--- a/genesis/tests/genesis4/test_pydantic_types.py
+++ b/genesis/tests/genesis4/test_pydantic_types.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 import numpy as np
 import pytest
-from pmd_beamphysics.units import pmd_unit
+from beamphysics.units import pmd_unit
 from pydantic import TypeAdapter
 
 from ...version4.types import NDArray, PydanticPmdUnit, Reference

--- a/genesis/tests/genesis4/test_run_particles.py
+++ b/genesis/tests/genesis4/test_run_particles.py
@@ -5,7 +5,7 @@ from math import pi, sqrt
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 from scipy.constants import c
 
 from ...version4 import Genesis4, Genesis4Input, Lattice, MainInput, Reference

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -17,8 +17,8 @@ from typing import (
 import h5py
 import numpy as np
 import pydantic
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 
 from .. import tools
 from .types import PydanticPmdUnit

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -37,6 +37,21 @@ _reserved_h5_attrs = {
 }
 
 
+def _msgpack_default(obj: Any) -> Any:
+    """Fallback serializer for types ormsgpack doesn't handle natively."""
+    if isinstance(obj, pmd_unit):
+        return {
+            "unitSI": obj.unitSI,
+            "unitSymbol": obj.unitSymbol,
+            "unitDimension": tuple(obj.unitDimension),
+        }
+    if isinstance(obj, ParticleGroup):
+        return obj.data
+    if isinstance(obj, pathlib.Path):
+        return str(obj)
+    raise TypeError(f"Type is not msgpack serializable: {type(obj).__name__}")
+
+
 def load_model_data(
     arch: str | pathlib.Path | h5py.Group,
     *,
@@ -63,7 +78,7 @@ def load_model_data(
         import ormsgpack
 
         assert not isinstance(arch, h5py.Group)
-        return ormsgpack.unpackb(arch.read_bytes())
+        return ormsgpack.unpackb(arch.read_bytes(), option=ormsgpack.OPT_NON_STR_KEYS)
 
     if format == "hdf5":
         if isinstance(arch, h5py.Group):
@@ -174,21 +189,23 @@ def dump_model(
         with h5py.File(dest, "w") as fp:
             store_in_hdf5_file(fp, model)
         return None
-    else:
+    elif format == "msgpack":
+        import ormsgpack
+
         data = model.model_dump(
             exclude_defaults=exclude_defaults,
             exclude_computed_fields=True,
-            mode="json",
+            mode="python",
         )
-        if format == "msgpack":
-            import ormsgpack
-
-            dumped = ormsgpack.packb(data, option=ormsgpack.OPT_SERIALIZE_NUMPY)
-            pathlib.Path(fname).write_bytes(dumped)
-        else:
-            raise NotImplementedError(format)
-
+        dumped = ormsgpack.packb(
+            data,
+            default=_msgpack_default,
+            option=ormsgpack.OPT_SERIALIZE_NUMPY | ormsgpack.OPT_NON_STR_KEYS,
+        )
+        pathlib.Path(fname).write_bytes(dumped)
         return data
+    else:
+        raise NotImplementedError(format)
 
 
 def _hdf5_dictify(

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import pathlib
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import h5py
 import numpy as np
@@ -17,12 +26,169 @@ from .types import PydanticPmdUnit
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_DATEFMT = "%Y%m%d_%H%M%S"
+T = TypeVar("T", bound=pydantic.BaseModel)
+ArchiveFormat = Literal["hdf5", "msgpack"]
 _reserved_h5_attrs = {
     "__python_class_name__",
     "__python_key_map__",
     "__python_key_order__",
     "__num_items__",
 }
+
+
+def load_model_data(
+    arch: str | pathlib.Path | h5py.Group,
+    *,
+    format: ArchiveFormat | None = None,
+):
+    """
+    Read the raw model data from a file in JSON, YAML, msgpack, or HDF5 format.
+
+    Parameters
+    ----------
+    arch : str or pathlib.Path or h5py.Group
+        The path to the file or an h5py.Group where the model data should be read from.
+        The file format is determined by the extension if a path is provided.
+    format : ArchiveFormat or None, optional
+        File format. If not specified, determined by file extension.
+    """
+    if isinstance(arch, h5py.Group):
+        format = "hdf5"
+    else:
+        arch = pathlib.Path(arch)
+        format = format or format_from_filename(arch)
+
+    if format == "msgpack":
+        import ormsgpack
+
+        assert not isinstance(arch, h5py.Group)
+        return ormsgpack.unpackb(arch.read_bytes())
+
+    if format == "hdf5":
+        if isinstance(arch, h5py.Group):
+            return restore_from_hdf5_file(arch)
+
+        with h5py.File(arch, "r") as fp:
+            return restore_from_hdf5_file(fp)
+
+    raise NotImplementedError(format)
+
+
+def format_from_filename(fn: pathlib.Path) -> ArchiveFormat:
+    if fn.suffix.lower() in (".msgpack", ".mpk"):
+        return "msgpack"
+
+    return "hdf5"
+
+
+def load_model(
+    arch: str | pathlib.Path | h5py.Group,
+    cls: type[T],
+    *,
+    format: ArchiveFormat | None = None,
+) -> T:
+    """
+    Read the model from a file in JSON, YAML, or msgpack format.
+
+    Parameters
+    ----------
+    arch : str, pathlib.Path, or h5py.Group
+        The path to the file where the model data should be written.
+        The file format is determined by the extension.
+    cls : pydantic.BaseModel class
+
+    format : ArchiveFormat or None, optional
+        File format.  If not specified, determined by file extension.
+    """
+    data = load_model_data(arch, format=format)
+    if isinstance(data, pydantic.BaseModel):
+        if not isinstance(data, cls):
+            raise TypeError(
+                f"Unexpected class returned from restore process. Expected {cls.__name__} "
+                f"got {type(data).__name__}"
+            )
+        return data
+    return cls.model_validate(data)
+
+
+def date_coded_rename(
+    dest: pathlib.Path, datefmt: str = "%Y%m%d_%H%M%S"
+) -> pathlib.Path | None:
+    """
+    Rename a destination path, adding a date-coded name suffix.
+
+    This is used in place of overwriting files, saving backups of the previous
+    data.
+    """
+    if not dest.exists():
+        return None
+
+    dt = datetime.datetime.now().strftime(datefmt)
+    backup_fn = f"{dest.stem}-{dt}{dest.suffix}"
+    dest.rename(dest.with_name(backup_fn))
+    return dest
+
+
+def dump_model(
+    dest: str | pathlib.Path | h5py.Group,
+    model: pydantic.BaseModel,
+    *,
+    exclude_defaults: bool = True,
+    backup_existing: bool = True,
+    datefmt: str = DEFAULT_DATEFMT,
+    format: ArchiveFormat | None = None,
+):
+    """
+    Write the model data to a file in JSON, YAML, or msgpack format.
+
+    Parameters
+    ----------
+    dest : str, pathlib.Path, or h5py.Group
+        The path to the file where the model data should be written.
+        The file format is determined by the extension.
+    model : pydantic.BaseModel
+
+    exclude_defaults : bool, optional
+        Exclude model defaults from the output. Defaults to True.
+    backup_existing : bool, optional
+        If a file exists at the target, rename it using `datefmt` as a backup.
+        Defaults to True.
+    datefmt : str, optional
+        The date format for the backup file.
+    format : ArchiveFormat or None, optional
+        File format.  If not specified, determined by file extension.
+    """
+
+    if isinstance(dest, h5py.Group):
+        store_in_hdf5_file(dest, model)
+        return
+
+    fname = pathlib.Path(dest)
+    format = format or format_from_filename(fname)
+
+    if backup_existing:
+        date_coded_rename(fname, datefmt=datefmt)
+
+    if format == "hdf5":
+        with h5py.File(dest, "w") as fp:
+            store_in_hdf5_file(fp, model)
+        return None
+    else:
+        data = model.model_dump(
+            exclude_defaults=exclude_defaults,
+            exclude_computed_fields=True,
+            mode="json",
+        )
+        if format == "msgpack":
+            import ormsgpack
+
+            dumped = ormsgpack.packb(data, option=ormsgpack.OPT_SERIALIZE_NUMPY)
+            pathlib.Path(fname).write_bytes(dumped)
+        else:
+            raise NotImplementedError(format)
+
+        return data
 
 
 def _hdf5_dictify(

--- a/genesis/version4/archive.py
+++ b/genesis/version4/archive.py
@@ -37,6 +37,9 @@ _reserved_h5_attrs = {
 }
 
 
+_MSGPACK_NDARRAY_MARKER = "__ndarray__"
+
+
 def _msgpack_default(obj: Any) -> Any:
     """Fallback serializer for types ormsgpack doesn't handle natively."""
     if isinstance(obj, pmd_unit):
@@ -47,9 +50,33 @@ def _msgpack_default(obj: Any) -> Any:
         }
     if isinstance(obj, ParticleGroup):
         return obj.data
+    if isinstance(obj, np.ndarray):
+        if obj.ndim == 0:
+            return obj.item()
+        arr = np.ascontiguousarray(obj)
+        return {
+            _MSGPACK_NDARRAY_MARKER: arr.tobytes(),
+            "dtype": str(arr.dtype),
+            "shape": list(arr.shape),
+        }
+    if isinstance(obj, np.generic):
+        return obj.item()
     if isinstance(obj, pathlib.Path):
         return str(obj)
     raise TypeError(f"Type is not msgpack serializable: {type(obj).__name__}")
+
+
+def _msgpack_restore_ndarrays(obj: Any) -> Any:
+    """Restore numpy arrays from the ``__ndarray__`` marker dicts."""
+    if isinstance(obj, dict):
+        if _MSGPACK_NDARRAY_MARKER in obj:
+            return np.frombuffer(
+                obj[_MSGPACK_NDARRAY_MARKER], dtype=obj["dtype"]
+            ).reshape(obj["shape"])
+        return {key: _msgpack_restore_ndarrays(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_msgpack_restore_ndarrays(item) for item in obj]
+    return obj
 
 
 def load_model_data(
@@ -78,7 +105,8 @@ def load_model_data(
         import ormsgpack
 
         assert not isinstance(arch, h5py.Group)
-        return ormsgpack.unpackb(arch.read_bytes(), option=ormsgpack.OPT_NON_STR_KEYS)
+        data = ormsgpack.unpackb(arch.read_bytes(), option=ormsgpack.OPT_NON_STR_KEYS)
+        return _msgpack_restore_ndarrays(data)
 
     if format == "hdf5":
         if isinstance(arch, h5py.Group):
@@ -200,7 +228,7 @@ def dump_model(
         dumped = ormsgpack.packb(
             data,
             default=_msgpack_default,
-            option=ormsgpack.OPT_SERIALIZE_NUMPY | ormsgpack.OPT_NON_STR_KEYS,
+            option=ormsgpack.OPT_NON_STR_KEYS,
         )
         pathlib.Path(fname).write_bytes(dumped)
         return data

--- a/genesis/version4/field.py
+++ b/genesis/version4/field.py
@@ -4,8 +4,8 @@ import pathlib
 import pydantic
 from typing import Union
 
-from pmd_beamphysics import Wavefront
-from pmd_beamphysics.units import Z0
+from beamphysics import Wavefront
+from beamphysics.units import Z0
 
 import h5py
 import numpy as np

--- a/genesis/version4/input/core.py
+++ b/genesis/version4/input/core.py
@@ -26,8 +26,8 @@ import numpy as np
 import pydantic
 import pydantic.alias_generators
 from lume import tools as lume_tools
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import c_light
+from beamphysics import ParticleGroup
+from beamphysics.units import c_light
 from typing_extensions import override
 
 from ... import tools

--- a/genesis/version4/input/core.py
+++ b/genesis/version4/input/core.py
@@ -1381,34 +1381,49 @@ class Genesis4Input(BaseModel):
             source_path=source_path,
         )
 
-    def archive(self, h5: h5py.Group) -> None:
+    def archive(
+        self,
+        dest: h5py.Group | str | pathlib.Path,
+        *,
+        format: _archive.ArchiveFormat = "hdf5",
+    ) -> None:
         """
-        Dump input data into the given HDF5 group.
+        Dump input data into the given file or HDF5 group.
 
         Parameters
         ----------
-        h5 : h5py.Group
+        dest : h5py.Group
             The HDF5 file in which to write the information.
         """
-        _archive.store_in_hdf5_file(h5, self)
+        if format == "hdf5":
+            if isinstance(dest, (str, pathlib.Path)):
+                with h5py.File(dest, "w") as fp:
+                    _archive.store_in_hdf5_file(fp, self)
+            else:
+                _archive.store_in_hdf5_file(dest, self)
+
+        else:
+            if isinstance(dest, h5py.Group):
+                raise ValueError(f"Unable to store HDF5 data into format {format}")
+
+            _archive.dump_model(dest, self)
 
     @classmethod
-    def from_archive(cls, h5: h5py.Group) -> Genesis4Input:
+    def from_archive(
+        cls,
+        arch: h5py.Group | pathlib.Path | str,
+        *,
+        format: _archive.ArchiveFormat | None = None,
+    ) -> Genesis4Input:
         """
-        Loads input from archived h5 file.
+        Loads input from archived file.
 
         Parameters
         ----------
-        h5 : str or h5py.File
+        arch : str, pathlib.Path or h5py.File
             The filename or handle on h5py.File from which to load data.
         """
-        loaded = _archive.restore_from_hdf5_file(h5)
-        if not isinstance(loaded, Genesis4Input):
-            raise ValueError(
-                f"Loaded {loaded.__class__.__name__} instead of a "
-                f"Genesis4Input instance.  Was the HDF group correct?"
-            )
-        return loaded
+        return _archive.load_model(arch, cls, format=format)
 
 
 class _MainInputTransformer(lark.visitors.Transformer_InPlaceRecursive):

--- a/genesis/version4/input/lattice.py
+++ b/genesis/version4/input/lattice.py
@@ -25,7 +25,7 @@ import matplotlib.axes
 import matplotlib.pyplot as plt
 import pydantic
 import pydantic.alias_generators
-from pmd_beamphysics.units import nice_array
+from beamphysics.units import nice_array
 from typing_extensions import override
 
 from ...errors import (

--- a/genesis/version4/interfaces/bmad.py
+++ b/genesis/version4/interfaces/bmad.py
@@ -1,7 +1,7 @@
 from ..input import Quadrupole, Corrector, Drift, Marker, Undulator
 from ..input import Setup, Field, Track, Beam
 
-from pmd_beamphysics.units import mec2
+from beamphysics.units import mec2
 
 from scipy.constants import c
 

--- a/genesis/version4/loadable.py
+++ b/genesis/version4/loadable.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Any, Literal
 
 import h5py
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 from .field import FieldFile
 from .particles import load_particle_group

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -43,6 +43,7 @@ from .types import (
     FileKey,
     NDArray,
     OutputDataType,
+    PydanticParticleGroup,
     PydanticPmdUnit,
 )
 
@@ -1406,7 +1407,7 @@ class Genesis4Output(Mapping, BaseModel, arbitrary_types_allowed=True):
         exclude=True,
         description="Loaded field data, keyed by filename base (e.g., 'end' of 'end.fld.h5').",
     )
-    particles: Dict[FileKey, ParticleGroup] = pydantic.Field(
+    particles: Dict[FileKey, PydanticParticleGroup] = pydantic.Field(
         default_factory=dict,
         description="Loaded particle data, keyed by integration step number or filename base.",
     )

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -1976,11 +1976,21 @@ class Genesis4Output(Mapping, BaseModel, arbitrary_types_allowed=True):
             shape=shape,
         )
 
-    def info(self):
+    def info(self, limit: int | None = None):
         """
         Get information about available string keys for the output.
+
+        Parameters
+        ----------
+        limit : int or None, optional
+            Limit the number of items shown.
         """
-        array_info = {key: self._get_array_info(key) for key in sorted(self.keys())}
+
+        keys = sorted(self.keys())
+        if limit:
+            keys = keys[:limit]
+
+        array_info = {key: self._get_array_info(key) for key in keys}
         shapes = {
             key: str(array_info.shape or "") for key, array_info in array_info.items()
         }

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -122,12 +122,16 @@ class _EmptyEqualityCheckNDArray(np.ndarray):
         # NOTE: this is strictly for equality checks when 'exclude_defaults" is
         # set for pydantic.
         if isinstance(other, np.ndarray):
-            return len(other.shape) == 0 and other.dtype == self.dtype
-        return len(other) == 0 and other.dtype == self.dtype
+            if other.size == 0 and self.size == 0:
+                return True
+            return False
+        if np.isscalar(other):
+            return False
+        return len(other) == 0
 
 
 def _empty_ndarray():
-    return _EmptyEqualityCheckNDArray([], dtype=np.float64)
+    return np.zeros(0).view(_EmptyEqualityCheckNDArray)
 
 
 class _OutputBase(BaseModel):

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -108,13 +108,26 @@ class RunInfo(BaseModel):
         return not self.error
 
 
+_zeros = np.zeros(0)
+
+
 class _EmptyEqualityCheckNDArray(np.ndarray):
+    def __repr__(self):
+        return repr(_zeros)
+
+    def __str__(self):
+        return str(_zeros)
+
     def __eq__(self, other):
+        # NOTE: this is strictly for equality checks when 'exclude_defaults" is
+        # set for pydantic.
+        if isinstance(other, np.ndarray):
+            return len(other.shape) == 0 and other.dtype == self.dtype
         return len(other) == 0 and other.dtype == self.dtype
 
 
 def _empty_ndarray():
-    return _EmptyEqualityCheckNDArray(0)
+    return _EmptyEqualityCheckNDArray([], dtype=np.float64)
 
 
 class _OutputBase(BaseModel):

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -108,8 +108,13 @@ class RunInfo(BaseModel):
         return not self.error
 
 
+class _EmptyEqualityCheckNDArray(np.ndarray):
+    def __eq__(self, other):
+        return len(other) == 0 and other.dtype == self.dtype
+
+
 def _empty_ndarray():
-    return np.zeros(0)
+    return _EmptyEqualityCheckNDArray(0)
 
 
 class _OutputBase(BaseModel):
@@ -1770,34 +1775,49 @@ class Genesis4Output(Mapping, BaseModel, arbitrary_types_allowed=True):
         """
         return self[key]
 
-    def archive(self, h5: h5py.Group) -> None:
+    def archive(
+        self,
+        dest: h5py.Group | str | pathlib.Path,
+        *,
+        format: _archive.ArchiveFormat = "hdf5",
+    ) -> None:
         """
-        Dump outputs into the given HDF5 group.
+        Dump output data into the given file or HDF5 group.
 
         Parameters
         ----------
-        h5 : h5py.Group
+        dest : h5py.Group
             The HDF5 file in which to write the information.
         """
-        _archive.store_in_hdf5_file(h5, self)
+        if format == "hdf5":
+            if isinstance(dest, (str, pathlib.Path)):
+                with h5py.File(dest, "w") as fp:
+                    _archive.store_in_hdf5_file(fp, self)
+            else:
+                _archive.store_in_hdf5_file(dest, self)
+
+        else:
+            if isinstance(dest, h5py.Group):
+                raise ValueError(f"Unable to store HDF5 data into format {format}")
+
+            _archive.dump_model(dest, self)
 
     @classmethod
-    def from_archive(cls, h5: h5py.Group) -> Genesis4Output:
+    def from_archive(
+        cls,
+        arch: h5py.Group | pathlib.Path | str,
+        *,
+        format: _archive.ArchiveFormat | None = None,
+    ) -> Genesis4Output:
         """
-        Loads output from the given HDF5 group.
+        Loads output from archived file.
 
         Parameters
         ----------
-        h5 : str or h5py.File
-            The key to use when restoring the data.
+        arch : str, pathlib.Path or h5py.File
+            The filename or handle on h5py.File from which to load data.
         """
-        loaded = _archive.restore_from_hdf5_file(h5)
-        if not isinstance(loaded, Genesis4Output):
-            raise ValueError(
-                f"Loaded {loaded.__class__.__name__} instead of a "
-                f"Genesis4Output instance.  Was the HDF group correct?"
-            )
-        return loaded
+        return _archive.load_model(arch, cls, format=format)
 
     def plot(
         self,

--- a/genesis/version4/output.py
+++ b/genesis/version4/output.py
@@ -26,8 +26,8 @@ import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 import pydantic
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import c_light, pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import c_light, pmd_unit
 from typing_extensions import override
 
 from .. import tools

--- a/genesis/version4/parsers.py
+++ b/genesis/version4/parsers.py
@@ -9,7 +9,7 @@ import numpy as np
 import pydantic.alias_generators
 from lume import tools
 from lume.parsers.namelist import parse_simple_namelist, parse_unrolled_namelist
-from pmd_beamphysics.units import e_charge, known_unit, mec2, pmd_unit
+from beamphysics.units import e_charge, known_unit, mec2, pmd_unit
 
 # Patch these into the lookup dict.
 known_unit["mec2"] = pmd_unit("m_ec^2", mec2 * e_charge, "energy")

--- a/genesis/version4/particles.py
+++ b/genesis/version4/particles.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional, Type, TypeVar, Union
 import h5py
 import numpy as np
 import pydantic
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.interfaces.genesis import genesis4_par_to_data
+from beamphysics import ParticleGroup
+from beamphysics.interfaces.genesis import genesis4_par_to_data
 
 from .types import BaseModel, AnyPath, NDArray
 

--- a/genesis/version4/plot.py
+++ b/genesis/version4/plot.py
@@ -7,8 +7,8 @@ import matplotlib.axes
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
-from pmd_beamphysics.labels import mathlabel
-from pmd_beamphysics.units import nice_array, nice_scale_prefix
+from beamphysics.labels import mathlabel
+from beamphysics.units import nice_array, nice_scale_prefix
 
 if typing.TYPE_CHECKING:
     from .output import Genesis4Output

--- a/genesis/version4/run.py
+++ b/genesis/version4/run.py
@@ -15,8 +15,8 @@ import psutil
 from lume import tools as lume_tools
 from lume.base import CommandWrapper
 import pydantic
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 from typing_extensions import override
 
 from .. import tools

--- a/genesis/version4/run.py
+++ b/genesis/version4/run.py
@@ -14,6 +14,7 @@ import h5py
 import psutil
 from lume import tools as lume_tools
 from lume.base import CommandWrapper
+import pydantic
 from pmd_beamphysics import ParticleGroup
 from pmd_beamphysics.units import pmd_unit
 from typing_extensions import override
@@ -21,6 +22,12 @@ from typing_extensions import override
 from .. import tools
 from ..errors import Genesis4RunFailure
 from . import parsers
+from .archive import (
+    DEFAULT_DATEFMT,
+    ArchiveFormat,
+    dump_model,
+    load_model,
+)
 from .field import FieldFile
 from .input import Genesis4Input, Lattice, MainInput
 from .output import Genesis4Output, RunInfo
@@ -126,6 +133,11 @@ def _make_genesis4_input(
         lattice_filename=lattice_fn,
         source_path=source_path,
     )
+
+
+class _Genesis4Archive(pydantic.BaseModel):
+    input: Genesis4Input
+    output: Optional[Genesis4Output] = None
 
 
 class Genesis4(CommandWrapper):
@@ -569,13 +581,21 @@ class Genesis4(CommandWrapper):
     def initial_field(self, value: Optional[FieldFile]) -> None:
         self.input.initial_field = value
 
-    def _archive(self, h5: h5py.Group):
+    def _archive_to_hdf5(self, h5: h5py.Group):
         self.input.archive(h5.create_group("input"))
         if self.output is not None:
             self.output.archive(h5.create_group("output"))
 
     @override
-    def archive(self, dest: Union[AnyPath, h5py.Group]) -> None:
+    def archive(
+        self,
+        dest: Union[AnyPath, h5py.Group],
+        *,
+        format: ArchiveFormat | None = None,
+        exclude_defaults: bool = True,
+        backup_existing: bool = True,
+        datefmt: str = DEFAULT_DATEFMT,
+    ) -> None:
         """
         Archive the latest run, input and output, to a single HDF5 file.
 
@@ -583,11 +603,15 @@ class Genesis4(CommandWrapper):
         ----------
         dest : filename or h5py.Group
         """
-        if isinstance(dest, (str, pathlib.Path)):
-            with h5py.File(dest, "w") as fp:
-                self._archive(fp)
-        elif isinstance(dest, (h5py.File, h5py.Group)):
-            self._archive(dest)
+
+        dump_model(
+            dest,
+            _Genesis4Archive(input=self.input, output=self.output),
+            format=format,
+            exclude_defaults=exclude_defaults,
+            backup_existing=backup_existing,
+            datefmt=datefmt,
+        )
 
     to_hdf5 = archive
 
@@ -599,7 +623,9 @@ class Genesis4(CommandWrapper):
             self.output = None
 
     @override
-    def load_archive(self, arch: Union[AnyPath, h5py.Group]) -> None:
+    def load_archive(
+        self, arch: AnyPath | h5py.Group, *, format: ArchiveFormat | None = None
+    ) -> None:
         """
         Load an archive from a single HDF5 file into this Genesis4 object.
 
@@ -607,15 +633,15 @@ class Genesis4(CommandWrapper):
         ----------
         arch : filename or h5py.Group
         """
-        if isinstance(arch, (str, pathlib.Path)):
-            with h5py.File(arch, "r") as fp:
-                self._load_archive(fp)
-        elif isinstance(arch, (h5py.File, h5py.Group)):
-            self._load_archive(arch)
+        data = load_model(arch, _Genesis4Archive, format=format)
+        self._input = data.input
+        self.output = data.output
 
     @override
     @classmethod
-    def from_archive(cls, arch: Union[AnyPath, h5py.Group]) -> Genesis4:
+    def from_archive(
+        cls, arch: Union[AnyPath, h5py.Group], *, format: ArchiveFormat | None = None
+    ) -> Genesis4:
         """
         Create a new Genesis4 object from an archive file.
 
@@ -624,7 +650,7 @@ class Genesis4(CommandWrapper):
         arch : filename or h5py.Group
         """
         inst = cls()
-        inst.load_archive(arch)
+        inst.load_archive(arch, format=format)
         return inst
 
     @classmethod

--- a/genesis/version4/types.py
+++ b/genesis/version4/types.py
@@ -20,8 +20,8 @@ from typing import (
 import numpy as np
 import pydantic
 import pydantic_core
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 from typing_extensions import NotRequired, TypedDict, override
 
 if TYPE_CHECKING:

--- a/genesis/version4/types.py
+++ b/genesis/version4/types.py
@@ -276,6 +276,8 @@ class _PydanticNDArray:
             return value
         if isinstance(value, Sequence):
             return np.asarray(value)
+        if np.isscalar(value):
+            return np.asarray([value])
         raise ValueError(f"No conversion from {value!r} to numpy ndarray")
 
 
@@ -301,6 +303,12 @@ class Reference(str):
 
 class NameList(BaseModel, abc.ABC):
     """Base class for name lists used in Genesis 4 main input files."""
+
+    @pydantic.model_serializer(mode="wrap")
+    def _always_include_type(self, next_serializer):
+        dumped = next_serializer(self)
+        dumped["type"] = self.type
+        return dumped
 
     @property
     def _to_genesis_params(self) -> Dict[str, ValueType]:
@@ -367,6 +375,12 @@ class BeamlineElement(BaseModel, abc.ABC):
     """Base class for beamline elements used in Genesis 4 lattice files."""
 
     label: str
+
+    @pydantic.model_serializer(mode="wrap")
+    def _always_include_type(self, next_serializer):
+        dumped = next_serializer(self)
+        dumped["type"] = self.type
+        return dumped
 
     @property
     def _to_genesis_params(self) -> Dict[str, ValueType]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "ormsgpack",
   "prettytable",
   "psutil",
-  "pydantic >2",
+  "pydantic >=2.12.0",
   "pydantic-settings",
   "scipy>=1.0.0",
   "typing-extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,13 @@ dependencies = [
   "matplotlib",
   "numpy",
   "openpmd-beamphysics >=0.11.0",
+  "ormsgpack",
   "prettytable",
   "psutil",
   "pydantic >2",
   "pydantic-settings",
-  "typing-extensions",
-  # Picking up pmd-beamphysics deps for now:
   "scipy>=1.0.0",
-  "python-dateutil",
+  "typing-extensions",
 ]
 description = "LUME tools for using Genesis 1.3 version 2 and version 4"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "lume-base",
   "matplotlib",
   "numpy",
-  "openpmd-beamphysics >=0.11.0",
+  "openpmd-beamphysics >=0.14.1",
   "ormsgpack",
   "prettytable",
   "psutil",


### PR DESCRIPTION
## Changes

* Added support for archiving and restoring Genesis4 data using the `msgpack` format alongside HDF5. To use it, simply pick the right extension (or set `format=`):
  ```python
  G.archive("file.msgpack")
  ```
* Added backup logic for existing files using date-coded renaming when archiving
* Updated the dependency list to include `ormsgpack` and require a newer version of `openpmd-beamphysics` (with `beamphysics` import).
* Replaced all imports from `pmd_beamphysics` with `beamphysics` throughout the codebase

### Benchmark

A small benchmark:

**G.archive()** 2,785,280 particles across 5 group(s)
**Iterations per format:** 5

| Metric | HDF5 | Msgpack | Comparison (Msgpack vs HDF5) |
|---|---|---|---|
| File Size | 194.72 MB | 192.95 MB | 0.99x (a little bit smaller) |
| Write Mean ± Stdev | 0.3315 ± 0.0018 s | 0.0887 ± 0.0194 s | 3.74x |
| Write Min | 0.3289 s | 0.0732 s | - |
| Write Max | 0.3335 s | 0.1221 s | - |
| Read Mean ± Stdev | 0.8656 ± 0.0129 s | 0.5165 ± 0.0268 s | 1.68x |
| Read Min | 0.8543 s | 0.5004 s | - |
| Read Max | 0.8878 s | 0.5641 s | - |
| **Total (Round-trip) Mean ± Stdev** | **1.1971 ± 0.0114 s** | **0.6053 ± 0.0458 s** | **1.98x** |
| Total Min | 1.1878 s | 0.5736 s | - |
| Total Max | 1.2166 s | 0.6862 s | - |
