### PR TITLE
MAINT: update to v4.6.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - typing-extensions
   # Genesis - OpenMPI variants
   - genesis2=*=mpi_openmpi*
-  - genesis4 >=4.6.8=mpi_openmpi*
+  - genesis4 >=4.6.12=mpi_openmpi*
   - h5py=*=mpi_openmpi*
   - openmpi
   # Required for all codebase features:

--- a/genesis/tests/genesis4/main_input.md
+++ b/genesis/tests/genesis4/main_input.md
@@ -20,6 +20,7 @@ The following describes all supported namelist with their variables, including i
     - [profile_step](#profile_step)
     - [profile_polynom](#profile_polynom)
     - [profile_file](#profile_file)
+    - [profile_file_multi](#profile_file_multi)
   - [sequence](#sequences)
     - [sequence_const](#sequence_const)
     - [sequence_polynom](#sequence_polynom)
@@ -164,12 +165,25 @@ Profiles are defining a dependence on the position in the time frame, which then
 
 #### profile_file
 
+Reading look-up tables from an HDF5 file.
 - `label`(*string, \<empty>*): Name of the profile, which is used to refer to it in later calls of namelists
 - `xdata` (*string, \<empty>*): Points to a dataset in an HDF5 file to define the `s`-position for the look-up table. The format is `filename/group1/.../groupn/datasetname`, where the naming of groups is not required if the dataset is at root level of the HDF file
 - `ydata` (*string, \<empty>*): Same as y data but for the function values of the look-up table.
 - `isTime` (*bool, false*): If true the `s`-position is a time variable and therefore multiplied with the speed of light `c` to get the position in meters.
 - `reverse`(*bool, false*): if true the order in the look-up table is reverse. This is sometimes needed because time and spatial coordinates differ sometimes by a minus sign.
-- `autoassign`(*bool, false*): use the HDF5 file from `xdata` (TODO more details).
+- `autoassign`(*bool, false*): use the dataset name of `ydata` as the label. I does not overwrite the label if it is explicitly defined in the namelist
+
+#### profile_file_multi
+
+A wrapper around `profile_file`.
+
+- `file`(*string, \<empty>*): Name of the HDF5 file, which contains all the dataset
+- `xdata` (*string, \<empty>*): Points to a dataset in an HDF5 file to define the `s`-position for the look-up table. The format is `group1/.../groupn/datasetname`, where the naming of groups is not required if the dataset is at root level of the HDF file
+- `ydata` (*string, \<empty>*): A comma separated list of multiple dataset names. The individual format is the same as `xdata` but for the function values of the look-up table.
+- `label_prefix` (*string,\<empty>*): The labels are generated with this prefix, a comma and the individual name of the dataset, given in `ydata`
+- `isTime` (*bool, false*): If true the `s`-position is a time variable and therefore multiplied with the speed of light `c` to get the position in meters.
+- `reverse`(*bool, false*): if true the order in the look-up table is reverse. This is sometimes needed because time and spatial coordinates differ sometimes by a minus sign.
+
 
 [Back](#supported-namelists)
 
@@ -354,7 +368,7 @@ The modules controls the import of a Genesis 1.3 field file to replace the inter
 - `harmonic` (*int, 1*) defines the harmonic for the given Genesis run.
 - `time` (*bool, true*): If the time window hasn’t been defined it allows to run Genesis with the imported distribution in scan mode, when set to `false`. This would disable all slippage and long-range collective effects in the simulation
 - `attenuation` (*double, 1.0*): apply an on-the-flight scaling factor to the field to be imported, without the need of modifying the original field file.
-- `offset` (*double, 0*): currently unused.
+- `offset` (*double, 0*): Additional offset of the field with respect to the time frame. It should be an integer of the slice length as defined in the field dump file
 
 [Back](#supported-namelists)
 
@@ -451,7 +465,9 @@ With this name list the field or particle distributions are dumped. The placehol
 ### track
 
 This namelist initiate the actually tracking through the undulator and then writing out the results. Normally all parameter should be defined before or defined in the lattice but the namelist allows some ’last minute’ change of the behavior of the code
-
+It allows also to chose the type of field solver. The default behaviour is the alternate direction implicit solver, which works for the majority of the cases. Some improvement in the field propagation of strongly divergent fields are better described by an FFT based solver. However it takes more computational time
+The fft methods allows also to filter the source term to exclude unphysical strongly divergent modes, which can bounce of the grid edge, resulting in model pattern of the wavefront. However a very agressive filtering can also
+affect the actual FEL process. It is recommended to not use it unless you are very familiar with the code and its affect.
 - `zstop` (*double, 1e9*): If `zstop` is shorter than the lattice length the tracking stops at the specified position.
 - `output_step` (*int, 1*): Defines the number of integration steps before the particle and field distribution is analyzed for output.
 - `field_dump_step` (*int, 0*): Defines the number of integration steps before a field dump is written. Be careful because for time-dependent simulation it can generate many large output files.
@@ -462,7 +478,11 @@ This namelist initiate the actually tracking through the undulator and then writ
 - `field_dump_at_undexit` (*bool, false*): Field dumps at the exit of the undulator (one dump for each undulator in the expanded lattice).
 - `bunchharm` (*int, 1*): Bunching harmonic output setting. Must be >= 1.
 - `exclusive_harmonics` (*bool, false*): If set to true than only the requested bunching harmonic is included in output. Otherwise all harmonic sup and including the specified harmonics are included.
-
+- `fft_fieldsolver` (*bool, false*): Selects an FFT based field solver to propagate the field instead of the Alternating Direction Implicit (ADI) method. The methods is more accurate for stronger divergent modes but increases the calculation time. The core routine to advance the field takes about a factor 3 more time
+- `source_filter` (*bool, false*): Allows to filter the source term  in the field equation with a 2D sigmoid function to supress strongly diffracting modes, e.g. in the case of a very granual electron distribution. This option is only supported for the FFT based field solver
+- `xcut` (*double,1.*): relative cut in the spatial frequency components in the x-direction. A value of 1 aligns the edge of the sigmoid filter to half of the maximum resolvable frequency
+- `ycut` (*double, 1.*): same for the y direction
+- `sigmoid` (*double, 1.*): relative steepnes of the sigmoid filter.
 
 [Back](#supported-namelists)
 

--- a/genesis/version4/input/_main.py
+++ b/genesis/version4/input/_main.py
@@ -808,6 +808,7 @@ class ProfilePolynom(types.NameList):
 
 class ProfileFile(types.NameList):
     r"""
+    Reading look-up tables from an HDF5 file.
 
     ProfileFile corresponds to Genesis 4 namelist `profile_file`.
 
@@ -828,7 +829,8 @@ class ProfileFile(types.NameList):
         if true the order in the look-up table is reverse. This is sometimes needed
         because time and spatial coordinates differ sometimes by a minus sign.
     autoassign : bool, default=False
-        use the HDF5 file from `xdata` (TODO more details).
+        use the dataset name of `ydata` as the label. I does not overwrite the label if
+        it is explicitly defined in the namelist
     """
 
     type: Literal["profile_file"] = "profile_file"
@@ -865,7 +867,76 @@ class ProfileFile(types.NameList):
     )
     autoassign: bool = pydantic.Field(
         default=False,
-        description="use the HDF5 file from `xdata` (TODO more details).",
+        description=(
+            "use the dataset name of `ydata` as the label. I does not overwrite the "
+            "label if it is explicitly defined in the namelist"
+        ),
+    )
+
+
+class ProfileFileMulti(types.NameList):
+    r"""
+    Generates profile objects `<label_prefix>.gamma`, `<label_prefix>.delgam`,
+    `<label_prefix>.current`, etc., each one corresponding to one `&profile_file`.
+
+    ProfileFileMulti corresponds to Genesis 4 namelist `profile_file_multi`.
+
+    Attributes
+    ----------
+    file : str, default=""
+        HDF5 filename.
+    label_prefix : str, default=""
+        prefix for each object.
+    xdata : str, default=""
+        Points to a dataset in an HDF5 file to define the `s`-position for the look-up
+        table. The format is `filename/group1/.../groupn/datasetname`, where the naming
+        of groups is not required if the dataset is at root level of the HDF file
+    ydata : str, default=""
+        Same as y data but for the function values of the look-up table.
+    isTime : bool, default=False
+        If true the `s`-position is a time variable and therefore multiplied with the
+        speed of light `c` to get the position in meters.
+    reverse : bool, default=False
+        if true the order in the look-up table is reverse. This is sometimes needed
+        because time and spatial coordinates differ sometimes by a minus sign.
+    """
+
+    type: Literal["profile_file_multi"] = "profile_file_multi"
+    file: str = pydantic.Field(
+        default="",
+        description="HDF5 filename.",
+    )
+    label_prefix: str = pydantic.Field(
+        default="",
+        description="prefix for each object.",
+    )
+    xdata: str = pydantic.Field(
+        default="",
+        description=(
+            "Points to a dataset in an HDF5 file to define the `s`-position for the "
+            "look-up table. The format is `filename/group1/.../groupn/datasetname`, "
+            "where the naming of groups is not required if the dataset is at root level "
+            "of the HDF file"
+        ),
+    )
+    ydata: str = pydantic.Field(
+        default="",
+        description="Same as y data but for the function values of the look-up table.",
+    )
+    isTime: bool = pydantic.Field(
+        default=False,
+        description=(
+            "If true the `s`-position is a time variable and therefore multiplied with "
+            "the speed of light `c` to get the position in meters."
+        ),
+    )
+    reverse: bool = pydantic.Field(
+        default=False,
+        description=(
+            "if true the order in the look-up table is reverse. This is sometimes "
+            "needed because time and spatial coordinates differ sometimes by a minus "
+            "sign."
+        ),
     )
 
 
@@ -1608,7 +1679,8 @@ class ImportField(types.NameList):
         apply an on-the-flight scaling factor to the field to be imported, without the
         need of modifying the original field file.
     offset : float, default=0.0
-        currently unused.
+        Additional offset of the field with respect to the time frame. It should be an
+        integer of the slice length as defined in the field dump file
     """
 
     type: Literal["importfield"] = "importfield"
@@ -1640,7 +1712,10 @@ class ImportField(types.NameList):
     )
     offset: float = pydantic.Field(
         default=0.0,
-        description="currently unused.",
+        description=(
+            "Additional offset of the field with respect to the time frame. It should "
+            "be an integer of the slice length as defined in the field dump file"
+        ),
     )
 
 
@@ -2053,6 +2128,16 @@ class Track(types.NameList):
     writing out the results. Normally all parameter should be defined before or
     defined in the lattice but the namelist allows some ’last minute’ change of the
     behavior of the code
+    It allows also to chose the type of field solver. The default behaviour is the
+    alternate direction implicit solver, which works for the majority of the cases.
+    Some improvement in the field propagation of strongly divergent fields are
+    better described by an FFT based solver. However it takes more computational
+    time
+    The fft methods allows also to filter the source term to exclude unphysical
+    strongly divergent modes, which can bounce of the grid edge, resulting in model
+    pattern of the wavefront. However a very agressive filtering can also
+    affect the actual FEL process. It is recommended to not use it unless you are
+    very familiar with the code and its affect.
 
     Track corresponds to Genesis 4 namelist `track`.
 
@@ -2087,6 +2172,24 @@ class Track(types.NameList):
     exclusive_harmonics : bool, default=False
         If set to true than only the requested bunching harmonic is included in output.
         Otherwise all harmonic sup and including the specified harmonics are included.
+    fft_fieldsolver : bool, default=False
+        Selects an FFT based field solver to propagate the field instead of the
+        Alternating Direction Implicit (ADI) method. The methods is more accurate for
+        stronger divergent modes but increases the calculation time. The core routine
+        to advance the field takes about a factor 3 more time
+    source_filter : bool, default=False
+        Allows to filter the source term  in the field equation with a 2D sigmoid
+        function to supress strongly diffracting modes, e.g. in the case of a very
+        granual electron distribution. This option is only supported for the FFT based
+        field solver
+    xcut : float, default=1.0
+        relative cut in the spatial frequency components in the x-direction. A value of
+        1 aligns the edge of the sigmoid filter to half of the maximum resolvable
+        frequency
+    ycut : float, default=1.0
+        same for the y direction
+    sigmoid : float, default=1.0
+        relative steepnes of the sigmoid filter.
     """
 
     type: Literal["track"] = "track"
@@ -2154,6 +2257,40 @@ class Track(types.NameList):
             "are included."
         ),
     )
+    fft_fieldsolver: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Selects an FFT based field solver to propagate the field instead of the "
+            "Alternating Direction Implicit (ADI) method. The methods is more accurate "
+            "for stronger divergent modes but increases the calculation time. The core "
+            "routine to advance the field takes about a factor 3 more time"
+        ),
+    )
+    source_filter: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Allows to filter the source term  in the field equation with a 2D sigmoid "
+            "function to supress strongly diffracting modes, e.g. in the case of a very "
+            "granual electron distribution. This option is only supported for the FFT "
+            "based field solver"
+        ),
+    )
+    xcut: float = pydantic.Field(
+        default=1.0,
+        description=(
+            "relative cut in the spatial frequency components in the x-direction. A "
+            "value of 1 aligns the edge of the sigmoid filter to half of the maximum "
+            "resolvable frequency"
+        ),
+    )
+    ycut: float = pydantic.Field(
+        default=1.0,
+        description="same for the y direction",
+    )
+    sigmoid: float = pydantic.Field(
+        default=1.0,
+        description="relative steepnes of the sigmoid filter.",
+    )
 
 
 class AlterField(types.NameList):
@@ -2199,72 +2336,6 @@ class AlterField(types.NameList):
     spp_phi0: float = pydantic.Field(
         default=0.0,
         description="TODO",
-    )
-
-
-class ProfileFileMulti(types.NameList):
-    r"""
-    Generates profile objects `<label_prefix>.gamma`, `<label_prefix>.delgam`,
-    `<label_prefix>.current`, etc., each one corresponding to one `&profile_file`.
-
-    ProfileFileMulti corresponds to Genesis 4 namelist `profile_file_multi`.
-
-    Attributes
-    ----------
-    file : str, default=""
-        HDF5 filename.
-    label_prefix : str, default=""
-        prefix for each object.
-    xdata : str, default=""
-        Points to a dataset in an HDF5 file to define the `s`-position for the look-up
-        table. The format is `filename/group1/.../groupn/datasetname`, where the naming
-        of groups is not required if the dataset is at root level of the HDF file
-    ydata : str, default=""
-        Same as y data but for the function values of the look-up table.
-    isTime : bool, default=False
-        If true the `s`-position is a time variable and therefore multiplied with the
-        speed of light `c` to get the position in meters.
-    reverse : bool, default=False
-        if true the order in the look-up table is reverse. This is sometimes needed
-        because time and spatial coordinates differ sometimes by a minus sign.
-    """
-
-    type: Literal["profile_file_multi"] = "profile_file_multi"
-    file: str = pydantic.Field(
-        default="",
-        description="HDF5 filename.",
-    )
-    label_prefix: str = pydantic.Field(
-        default="",
-        description="prefix for each object.",
-    )
-    xdata: str = pydantic.Field(
-        default="",
-        description=(
-            "Points to a dataset in an HDF5 file to define the `s`-position for the "
-            "look-up table. The format is `filename/group1/.../groupn/datasetname`, "
-            "where the naming of groups is not required if the dataset is at root level "
-            "of the HDF file"
-        ),
-    )
-    ydata: str = pydantic.Field(
-        default="",
-        description="Same as y data but for the function values of the look-up table.",
-    )
-    isTime: bool = pydantic.Field(
-        default=False,
-        description=(
-            "If true the `s`-position is a time variable and therefore multiplied with "
-            "the speed of light `c` to get the position in meters."
-        ),
-    )
-    reverse: bool = pydantic.Field(
-        default=False,
-        description=(
-            "if true the order in the look-up table is reverse. This is sometimes "
-            "needed because time and spatial coordinates differ sometimes by a minus "
-            "sign."
-        ),
     )
 
 
@@ -2332,6 +2403,7 @@ AutogeneratedNameList = Union[
     ProfileStep,
     ProfilePolynom,
     ProfileFile,
+    ProfileFileMulti,
     SequenceConst,
     SequencePolynom,
     SequencePower,
@@ -2349,7 +2421,6 @@ AutogeneratedNameList = Union[
     Write,
     Track,
     AlterField,
-    ProfileFileMulti,
     SequenceList,
     SequenceFilelist,
 ]


### PR DESCRIPTION
The `&track` namelist has some new options:

- `fft_fieldsolver` (*bool, false*): Selects an FFT based field solver to propagate the field instead of the Alternating Direction Implicit (ADI) method. The methods is more accurate for stronger divergent modes but increases the calculation time. The core routine to advance the field takes about a factor 3 more time
- `source_filter` (*bool, false*): Allows to filter the source term  in the field equation with a 2D sigmoid function to supress strongly diffracting modes, e.g. in the case of a very granual electron distribution. This option is only supported for the FFT based field solver
- `xcut` (*double,1.*): relative cut in the spatial frequency components in the x-direction. A value of 1 aligns the edge of the sigmoid filter to half of the maximum resolvable frequency
- `ycut` (*double, 1.*): same for the y direction
- `sigmoid` (*double, 1.*): relative steepnes of the sigmoid filter.