### PR TITLE
FIX: ensure ParticleGroup serializes to json as well

### DIFF
--- a/genesis/tests/genesis4/test_archive.py
+++ b/genesis/tests/genesis4/test_archive.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import json
+import operator
 import pathlib
 import time
 from typing import Union
 
 import h5py
+import numpy as np
 import pytest
-from beamphysics import ParticleGroup
-from pydantic import BaseModel
+from beamphysics import ParticleGroup, single_particle
+from beamphysics.units import pmd_unit
+from pydantic import BaseModel, TypeAdapter
 
 from ...version4 import (
     AlterBeam,
@@ -47,11 +52,17 @@ from ...version4 import (
     Write,
 )
 from ...version4.archive import (
-    store_in_hdf5_file,
-    restore_from_hdf5_file,
     pick_from_archive,
+    restore_from_hdf5_file,
+    store_in_hdf5_file,
 )
-from ...version4.types import BeamlineElement, NameList
+from ...version4.types import (
+    BeamlineElement,
+    NameList,
+    NDArray,
+    PydanticParticleGroup,
+    PydanticPmdUnit,
+)
 from ..conftest import test_artifacts
 from . import util
 
@@ -396,3 +407,32 @@ def test_msgpack_archive_particles(
         particles = orig_particles[key]
         print("Checking particles", particles)
         assert particles == new_output.particles[key]
+
+
+@pytest.mark.parametrize(
+    "type_annotation, obj, comparator",
+    [
+        pytest.param(
+            PydanticPmdUnit,
+            pmd_unit.from_symbol("m"),
+            operator.eq,
+            id="pmd_unit",
+        ),
+        pytest.param(
+            PydanticParticleGroup,
+            single_particle(),
+            operator.eq,
+            id="particlegroup",
+        ),
+        pytest.param(
+            NDArray,
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            np.array_equal,
+            id="ndarray",
+        ),
+    ],
+)
+def test_json_serialization(type_annotation, obj, comparator):
+    adapter = TypeAdapter(type_annotation)
+    assert comparator(adapter.validate_python(adapter.dump_python(obj)), obj)
+    assert comparator(adapter.validate_json(adapter.dump_json(obj)), obj)

--- a/genesis/version4/types.py
+++ b/genesis/version4/types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import pathlib
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Dict,
@@ -14,7 +15,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    TYPE_CHECKING,
 )
 
 import numpy as np
@@ -174,8 +174,12 @@ class _PydanticParticleGroup:
     def _from_dict(data: ParticleData) -> ParticleGroup:
         return ParticleGroup(data=data)
 
-    def _as_dict(self) -> ParticleData:
-        return self.data
+    @staticmethod
+    def _as_dict(obj) -> dict:
+        return {
+            key: value.tolist() if isinstance(value, np.ndarray) else value
+            for key, value in obj.data.items()
+        }
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -214,11 +218,12 @@ class _PydanticPmdUnit:
             dim = tuple(dim)
         return pmd_unit(**dct, unitDimension=dim)
 
-    def _as_dict(self) -> Dict[str, Any]:
+    @staticmethod
+    def _as_dict(obj: pmd_unit) -> Dict[str, Any]:
         return {
-            "unitSI": self.unitSI,
-            "unitSymbol": self.unitSymbol,
-            "unitDimension": tuple(self.unitDimension),
+            "unitSI": obj.unitSI,
+            "unitSymbol": obj.unitSymbol,
+            "unitDimension": tuple(obj.unitDimension),
         }
 
     @classmethod


### PR DESCRIPTION
Previously untested (oops), `PydanticParticleGroup` was not dumping to JSON properly. This fixes and adds a test for it.